### PR TITLE
Add compile-time registration checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
   -------------------------------------------------------------------
 ## [Unreleased]
+ - Added more compile-time checks to raise descriptive errors on register. This also fixes a bug where circular dependencies could be registered.
 
 ## [0.2.0] 2020-01-23
  - Fixed an issue where nested `Module::Classes` could not be registered.

--- a/spec/compile_errors/circular.cr
+++ b/spec/compile_errors/circular.cr
@@ -1,0 +1,18 @@
+require "../../src/hardwire"
+
+class Dep1 
+  def initialize(@dep2 : Dep2)
+  end
+end
+
+class Dep2
+  def initialize(@dep1 : Dep1)
+  end
+end
+
+
+module CircContainer
+  include HardWire::Container
+  singleton Dep1
+  singleton Dep2
+end

--- a/spec/compile_errors/constructor_duplicate.cr
+++ b/spec/compile_errors/constructor_duplicate.cr
@@ -1,0 +1,25 @@
+require "../../src/hardwire"
+
+class ParentService
+end
+
+class SpecialService
+  # too many annotated constructors
+  @[HardWire::Inject]
+  def initialize(@parentService : ParentService)
+  end
+
+  # too many annotated constructors
+  @[HardWire::Inject]
+  def initialize(string : String)
+    @parentService = ParentService.new
+  end
+end
+
+class Container
+  include HardWire::Container
+
+  singleton ParentService
+  transient SpecialService
+end
+

--- a/spec/compile_errors/constructor_unknown.cr
+++ b/spec/compile_errors/constructor_unknown.cr
@@ -1,0 +1,22 @@
+require "../../src/hardwire"
+
+class ParentService
+end
+
+class SpecialService
+  def initialize(@parentService : ParentService)
+  end
+
+  # null constructor - how confusing
+  def initialize
+    @parentService = ParentService.new
+  end
+end
+
+class Container
+  include HardWire::Container
+
+  singleton ParentService
+  transient SpecialService
+end
+

--- a/spec/compile_errors/duplicate.cr
+++ b/spec/compile_errors/duplicate.cr
@@ -1,0 +1,12 @@
+require "../../src/hardwire"
+
+class SpecialService
+end
+
+class Container
+  include HardWire::Container
+
+  singleton SpecialService
+  singleton SpecialService
+end
+

--- a/spec/compile_errors/duplicate_different_lifecycles.cr
+++ b/spec/compile_errors/duplicate_different_lifecycles.cr
@@ -1,0 +1,12 @@
+require "../../src/hardwire"
+
+class SpecialService
+end
+
+class Container
+  include HardWire::Container
+
+  singleton SpecialService
+  transient SpecialService
+end
+

--- a/spec/compile_errors/duplicate_tags.cr
+++ b/spec/compile_errors/duplicate_tags.cr
@@ -1,0 +1,13 @@
+require "../../src/hardwire"
+
+class SpecialService
+end
+
+class Container
+  include HardWire::Container
+
+  singleton SpecialService, "one,two"
+  singleton SpecialService, "one,two,three" # not a duplicate
+  transient SpecialService, "one,two"
+end
+

--- a/spec/compile_errors/unregistered.cr
+++ b/spec/compile_errors/unregistered.cr
@@ -1,0 +1,16 @@
+require "../../src/hardwire"
+
+class RequiredDependency
+end
+
+class ParentService
+  def initialize(@requiredDependency : RequiredDependency)
+  end
+end
+
+
+module CircContainer
+  include HardWire::Container
+
+  singleton ParentService
+end

--- a/spec/compile_errors_spec.cr
+++ b/spec/compile_errors_spec.cr
@@ -1,0 +1,33 @@
+require "./spec_helper"
+
+# These are pretty brittle, but the string message matching should be kept to the minimum required to indicate the error.
+# This will give us the most flexibility for refactoring
+describe "HardWire" do
+  it "should fail to compile an unregistered dependency" do
+    assert_compile_error "compile_errors/unregistered.cr", "Error: HardWire/Missing Dependency: unabled to register (ParentService, []), missing requiredDependency: (RequiredDependency, [])"
+  end
+
+  it "should fail to compile a circular dependency" do
+    assert_compile_error "compile_errors/circular.cr", "Error: HardWire/Missing Dependency: unabled to register (Dep1, []), missing dep2: (Dep2, [])"
+  end
+
+  it "should fail to compile a duplicate dependency" do
+    assert_compile_error "compile_errors/duplicate.cr", "Error: HardWire/Duplicate Registration: existing (SpecialService, [])."
+  end
+
+  it "should fail to compile a duplicate dependency with tags" do
+    assert_compile_error "compile_errors/duplicate_tags.cr", "Error: HardWire/Duplicate Registration: existing (SpecialService, [\"one\", \"two\"])"
+  end
+
+  it "should fail to compile a duplicate dependency with a different lifecycle" do
+    assert_compile_error "compile_errors/duplicate_different_lifecycles.cr", "Error: HardWire/Duplicate Registration: existing (SpecialService, [])"
+  end
+
+  it "should fail to compile when a dependency has multiple, unannotated constructors" do
+    assert_compile_error "compile_errors/constructor_unknown.cr", "Error: HardWire/Unknown Constructor: target: SpecialService."
+  end
+
+  it "should fail to compile when a dependency has multiple annotated constructors" do
+    assert_compile_error "compile_errors/constructor_duplicate.cr", "Error: HardWire/Too Many Constructors: target: SpecialService."
+  end
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,2 +1,12 @@
 require "spec"
 require "../src/hardwire"
+
+# Pinched from Blacksmoke16
+# https://forum.crystal-lang.org/t/testing-compile-time-errors/272/3
+def assert_compile_error(path : String, message : String) : Nil
+  buffer = IO::Memory.new
+  result = Process.run("crystal", ["run", "--no-color", "--no-codegen", "spec/" + path], error: buffer)
+  result.success?.should be_false
+  buffer.to_s.should contain message
+  buffer.close
+end


### PR DESCRIPTION
Invoking compiler in spec tests with specific examples should give us
the confidence to say "yup, that failed!" it's not super scientific, but
checking for specific strings (provided they're unique enough) should be
a fair test.

Add error 'types' as prefixes, extra compilecases